### PR TITLE
Update Requests to 2.6.0 to deal with InsecurePlatformWarning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests==2.4.3
+requests==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(name='youtube_api',
           'Programming Language :: Python',
           'Topic :: Software Development :: Libraries :: Python Modules'],
       install_requires=[
-          'requests>=2.0'],
+          'requests>=2.6'],
       )


### PR DESCRIPTION
Hi Alex.
I got the following error when installing via pip:

`requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning`

I have updated your requirements and setup to use requests 2.6.
